### PR TITLE
Update interviews_clientlist.html

### DIFF
--- a/interviews/templates/interviews/interviews_clientlist.html
+++ b/interviews/templates/interviews/interviews_clientlist.html
@@ -27,7 +27,7 @@
 {% if interviews_list.exists %}
     {% block main_area %}
 
-    <div class="row sub-menu-bar py-5">
+    <div class="row sub-menu-bar py-5" style="height: max-content;">
 
         <div class="col-12 d-flex justify-content-center">
             <div class="row col-12 col-xl-11 justify-content-center" style="gap:20px;">


### PR DESCRIPTION
상단 메뉴가 아이패드의 크롬에서 길게 늘어나는 현상을 수정하기 위해서 상단 메뉴를 감싸는 div에 height: max-content;를 줬습니다.